### PR TITLE
Advanced Duplicator Support

### DIFF
--- a/lua/entities/keypad/init.lua
+++ b/lua/entities/keypad/init.lua
@@ -118,6 +118,7 @@ function ENT:SetData(data)
 
 	self:SetPassword(data.Password or "1337")
 	self:Reset()
+	duplicator.StoreEntityModifier(self, "keypad_password_passthrough", self.KeypadData)
 end
 
 function ENT:GetData()
@@ -153,3 +154,8 @@ function ENT:Reset()
 	self:SetStatus(self.Status_None)
 	self:SetSecure(self:GetData().Secure)
 end
+
+
+duplicator.RegisterEntityModifier( "keypad_password_passthrough", function(ply, entity, data)
+    entity:SetData(data)
+end)

--- a/lua/entities/keypad_wire/init.lua
+++ b/lua/entities/keypad_wire/init.lua
@@ -118,6 +118,7 @@ function ENT:SetData(data)
 
 	self:SetPassword(data.Password or "1337")
 	self:Reset()
+	duplicator.StoreEntityModifier(self, "keypad_wire_password_passthrough", self.KeypadData)
 end
 
 function ENT:GetData()
@@ -162,3 +163,7 @@ function ENT:Reset()
 	Wire_TriggerOutput(self, "Access Granted", self.KeypadData.OutputOff)
 	Wire_TriggerOutput(self, "Access Denied", self.KeypadData.OutputOff)
 end
+
+duplicator.RegisterEntityModifier( "keypad_wire_password_passthrough", function(ply, entity, data)
+    entity:SetData(data)
+end)


### PR DESCRIPTION
These changes allow the keypads to be duplicated with adv dupe 1 & 2 correctly.